### PR TITLE
SCADA without RX and with interpretator fix

### DIFF
--- a/DbEditorXML.exe
+++ b/DbEditorXML.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e398d6bdd1191b18df3e6d2ddc8ac370a5abdd83dedc2b88dbc2fd648e04e06
-size 21775933

--- a/DbEditorXML.exe
+++ b/DbEditorXML.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e2ebd93feca16b4461cde7a285d128b75e32ce17e57b249021dc052cb83e3eec
-size 21906604
+oid sha256:3e398d6bdd1191b18df3e6d2ddc8ac370a5abdd83dedc2b88dbc2fd648e04e06
+size 21775933

--- a/DbEditorXML.exe
+++ b/DbEditorXML.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:399b16e73bdd387a7e3bb1c5feb6dc738c8d67eefc4109901b555c681bc217ad
+size 16112972

--- a/EasyServer.exe
+++ b/EasyServer.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c67f880a0dd0a6f2cba206a434df1f482824d1077a9411cb12318a4150e4dfdb
-size 16939520

--- a/EasyServer.exe
+++ b/EasyServer.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65aca1e32df0ef6cb55b3c9c038038d3768e1fa0f345bdde4401423ff98ee4b7
-size 17084928
+oid sha256:c67f880a0dd0a6f2cba206a434df1f482824d1077a9411cb12318a4150e4dfdb
+size 16939520

--- a/EasyServer.exe
+++ b/EasyServer.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17228c0c35db258fc729615d3d88a9818e25b027ad9145f86ae6fabcd42f1e76
+size 16943104

--- a/Monitor.exe
+++ b/Monitor.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8c857c2672e1654f76186b71ae47db0ae23ffdea033f6624ad76a648a2b6568
+size 21956608

--- a/Monitor.exe
+++ b/Monitor.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:67606aef3e2b6b5d0153f240ab8cf4163caae8e82ebfe0b2906616d3b8cf1959
-size 22168576
+oid sha256:1f72b5e4e6d78b1ca8df6fa35edd684d6f4fca33bbc099cfade486821cdc5baa
+size 21953536

--- a/Monitor.exe
+++ b/Monitor.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1f72b5e4e6d78b1ca8df6fa35edd684d6f4fca33bbc099cfade486821cdc5baa
-size 21953536

--- a/services/ClientPLog.dll
+++ b/services/ClientPLog.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7260eaf6961e3ede735ba10fb8802ccfae5993a6793f54474638be4bfbbc8495
-size 2725888
+oid sha256:1d96a4565fe32e21898774e3f9aa699f0dfc2ab544c214b342c619ca60768a5e
+size 2727424

--- a/services/ClientPLog.dll
+++ b/services/ClientPLog.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d96a4565fe32e21898774e3f9aa699f0dfc2ab544c214b342c619ca60768a5e
+oid sha256:15b1c6d362fef09594134bb8ee7b25c75e378fdaa8e57050c8643cff2c7541fa
 size 2727424

--- a/services/ClientPLog.dll
+++ b/services/ClientPLog.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15b1c6d362fef09594134bb8ee7b25c75e378fdaa8e57050c8643cff2c7541fa
+oid sha256:b24ae5ea19481d58c9e8892a6d345301de3b423dbd1643c2cf3f677b375e9a53
 size 2727424

--- a/services/ClientTLog.dll
+++ b/services/ClientTLog.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e242ebfe18c8e5c32496ab8961cd5b0331b667158fc1d56c6c82214b9715b793
+oid sha256:c66c26563e36860aef8968b7b679ced21db24b54bb631f77dc3efa07fad2dc72
 size 2727424

--- a/services/ClientTLog.dll
+++ b/services/ClientTLog.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c66c26563e36860aef8968b7b679ced21db24b54bb631f77dc3efa07fad2dc72
+oid sha256:27c5f1266e41617641b4f37144d809739ae34e6e4d3e0d86c20a347d905a586f
 size 2727424

--- a/services/ClientTLog.dll
+++ b/services/ClientTLog.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6c1d92efbd35fcf15753b9ea9c6bf0f575b387c6833e07e18601848d0975d0cb
-size 2725888
+oid sha256:e242ebfe18c8e5c32496ab8961cd5b0331b667158fc1d56c6c82214b9715b793
+size 2727424

--- a/services/ConnectionLog.dll
+++ b/services/ConnectionLog.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b17a8656b39fd137a3a736d179e926e2b1c6fb36510728fec6be950e4a2f66e3
-size 2725888
+oid sha256:39fb2b31eb0cb33eadc8f040a052688996736e0514dd540f4f68a332420d2a3a
+size 2727424

--- a/services/ConnectionLog.dll
+++ b/services/ConnectionLog.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:390eeb32cf01c7e547df29c469dd528fb2c30f19facff84a2cf32f09f93d71da
+oid sha256:515fa968ed44bbb9fee832fd9c2b58f1d44fe23328f907d5b783718ba6694b98
 size 2727424

--- a/services/ConnectionLog.dll
+++ b/services/ConnectionLog.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:39fb2b31eb0cb33eadc8f040a052688996736e0514dd540f4f68a332420d2a3a
+oid sha256:390eeb32cf01c7e547df29c469dd528fb2c30f19facff84a2cf32f09f93d71da
 size 2727424

--- a/services/buglog.dll
+++ b/services/buglog.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2951f2a49504bf9f197865576899d8fd8ab79a1b7b6e3ecbfda33ab804f3b0c1
+oid sha256:d225f12e9a5f2aaabd064072f68f08c73bbbabb3d0e4b8c894834c25742a320f
 size 2728960

--- a/services/buglog.dll
+++ b/services/buglog.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24371a0d393d5def99d127fb09ce35c953f61b1afab1d80facdf1f3e41c5f269
+oid sha256:2951f2a49504bf9f197865576899d8fd8ab79a1b7b6e3ecbfda33ab804f3b0c1
 size 2728960

--- a/services/buglog.dll
+++ b/services/buglog.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06ce99a2a4cde25ee9d4ef3fa9b2346a52e8adf7ddc1b477a833b8b188d5f755
-size 2726912
+oid sha256:24371a0d393d5def99d127fb09ce35c953f61b1afab1d80facdf1f3e41c5f269
+size 2728960

--- a/services/propservice.dll
+++ b/services/propservice.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0ecee198a5c25e2f0a6899af5982d0b4ccaf4bd9abd5a7f6de725ad4ab7b648
+oid sha256:f416da86b8fb25db8a91a97f977696c75f0dc3af33ebe463beec513f64b84628
 size 2802688

--- a/services/propservice.dll
+++ b/services/propservice.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24bc6a059ad0f04185598c98a824b013dbba49389ac58e653290b8c0a0aa9b63
+oid sha256:d0ecee198a5c25e2f0a6899af5982d0b4ccaf4bd9abd5a7f6de725ad4ab7b648
 size 2802688

--- a/services/propservice.dll
+++ b/services/propservice.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2951c9a7d0727fbfccc4cbf6f848f2e55b11bb557eec8f47a60e6cc08d67b567
-size 2783744
+oid sha256:24bc6a059ad0f04185598c98a824b013dbba49389ac58e653290b8c0a0aa9b63
+size 2802688


### PR DESCRIPTION
Исходный код можно взять [тут](https://github.com/savushkin-r-d/SCADA/releases/tag/2024.11.18).